### PR TITLE
Add L3 option to orderbook feed

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Mango v4 Geyser Services
   A service providing lowest-latency, bandwidth conserving access to fill events for Mango V4 Perp and Openbook markets
   as they are processed by the rpc node.
 
-  - [`service-mango-pnl/`](service-mango-pnl/)
+- [`service-mango-pnl/`](service-mango-pnl/)
 
-  A service providing pre-computed account lists ordered by unsettled PnL per market
+A service providing pre-computed account lists ordered by unsettled PnL per market
 
-  - [`service-mango-orderbook/`](service-mango-pnl/)
+- [`service-mango-orderbook/`](service-mango-pnl/)
 
-  A service providing Orderbook L2 state and delta updates for Mango V4 Perp and Openbook Spot markets
+A service providing Orderbook L2/L3 state and delta updates for Mango V4 Perp and Openbook Spot markets

--- a/service-mango-orderbook/README.md
+++ b/service-mango-orderbook/README.md
@@ -1,6 +1,6 @@
 # service-mango-orderbook
 
-This module parses bookside accounts and exposes L2 data and updates on a websocket
+This module parses bookside accounts and exposes L2 and L3 data and updates on a websocket
 
 Public API: `https://api.mngo.cloud/orderbook/v1/`
 
@@ -22,19 +22,22 @@ Get a list of markets
 }
 ```
 
-Subscribe to markets
+### L2 Data 
+
+Subscribe to L2 updates
 
 ```
 {
-   "command": "subscribe"
-   "marketId": "MARKET_PUBKEY"
+   "command": "subscribe",
+   "marketId": "MARKET_PUBKEY",
+   "subscriptionType": "level",
 }
 ```
 
 ```
 {
     "success": true,
-    "message": "subscribed to market MARKET_PUBKEY"
+    "message": "subscribed to level updates for MARKET_PUBKEY"
 }
 ```
 
@@ -68,6 +71,93 @@ L2 Update - Sent per side
     ],
     "slot": 190826375,
     "write_version": 688377208759
+}
+```
+### L3 Data 
+
+Subscribe to L3 updates
+
+```
+{
+   "command": "subscribe",
+   "marketId": "MARKET_PUBKEY",
+   "subscriptionType": "book",
+}
+```
+
+```
+{
+    "success": true,
+    "message": "subscribed to book updates for MARKET_PUBKEY"
+}
+```
+
+L3 Checkpoint - Sent upon initial subscription
+
+```
+{
+    "market": "ESdnpnNLgTkBCZRuTJkZLi5wKEZ2z47SG3PJrhundSQ2",
+    "bids": [
+        {
+          "price": 20.81,
+          "quantity": 1.3,
+          "owner_pubkey": "F1SZxEDxxCSLVjEBbMEjDYqajWRJQRCZBwPQnmcVvTLV"
+        },
+        {
+          "price": 20.81,
+          "quantity": 62.22,
+          "owner_pubkey": "BGYWnqfaauCeebFQXEfYuDCktiVG8pqpprrsD4qfqL53"
+        },
+        {
+          "price": 20.8,
+          "quantity": 8,
+          "owner_pubkey": "CtHuPg2ctVVV7nqmvVEcMtcWyJAgtZw9YcNHFQidjPgF"
+        }
+    ],
+    "asks": [
+        {
+          "price": 20.94,
+          "quantity": 62.22,
+          "owner_pubkey": "BGYWnqfaauCeebFQXEfYuDCktiVG8pqpprrsD4qfqL53"
+        },
+        {
+          "price": 20.95,
+          "quantity": 1.3,
+          "owner_pubkey": "F1SZxEDxxCSLVjEBbMEjDYqajWRJQRCZBwPQnmcVvTLV"
+        },
+        {
+          "price": 21.31,
+          "quantity": 30,
+          "owner_pubkey": "5gHsqmFsMaguM3HMyEmnME4NMQKj6NrJWUGv6VKnc2Hk"
+        }
+    ],
+    "slot": 190826373,
+    "write_version": 688377208758
+}
+```
+
+L3 Update - Sent per side
+
+```
+{
+    "market": "ESdnpnNLgTkBCZRuTJkZLi5wKEZ2z47SG3PJrhundSQ2",
+    "side": "ask",
+    "additions": [
+        {
+          "price": 20.92,
+          "quantity": 61.93,
+          "owner_pubkey": "BGYWnqfaauCeebFQXEfYuDCktiVG8pqpprrsD4qfqL53"
+        }
+      ],
+      "removals": [
+        {
+          "price": 20.92,
+          "quantity": 61.910000000000004,
+          "owner_pubkey": "BGYWnqfaauCeebFQXEfYuDCktiVG8pqpprrsD4qfqL53"
+        }
+      ],
+      "slot": 197077534,
+      "write_version": 727782187614
 }
 ```
 

--- a/service-mango-orderbook/README.md
+++ b/service-mango-orderbook/README.md
@@ -76,7 +76,7 @@ L2 Update - Sent per side
 ### L3 Data 
 
 Subscribe to L3 updates
-:warning: If the subscribed market is a perp market, `owner_pubkey` corresponds to a `mangoAccount`, if the subscribed market is a spot market, `owner_pubkey` corresponds to an open orders account.
+:warning: If the subscribed market is a perp market, `ownerPubkey` corresponds to a `mangoAccount`, if the subscribed market is a spot market, `ownerPubkey` corresponds to an open orders account.
 
 ```
 {
@@ -102,34 +102,34 @@ L3 Checkpoint - Sent upon initial subscription
         {
           "price": 20.81,
           "quantity": 1.3,
-          "owner_pubkey": "F1SZxEDxxCSLVjEBbMEjDYqajWRJQRCZBwPQnmcVvTLV"
+          "ownerPubkey": "F1SZxEDxxCSLVjEBbMEjDYqajWRJQRCZBwPQnmcVvTLV"
         },
         {
           "price": 20.81,
           "quantity": 62.22,
-          "owner_pubkey": "BGYWnqfaauCeebFQXEfYuDCktiVG8pqpprrsD4qfqL53"
+          "ownerPubkey": "BGYWnqfaauCeebFQXEfYuDCktiVG8pqpprrsD4qfqL53"
         },
         {
           "price": 20.8,
           "quantity": 8,
-          "owner_pubkey": "CtHuPg2ctVVV7nqmvVEcMtcWyJAgtZw9YcNHFQidjPgF"
+          "ownerPubkey": "CtHuPg2ctVVV7nqmvVEcMtcWyJAgtZw9YcNHFQidjPgF"
         }
     ],
     "asks": [
         {
           "price": 20.94,
           "quantity": 62.22,
-          "owner_pubkey": "BGYWnqfaauCeebFQXEfYuDCktiVG8pqpprrsD4qfqL53"
+          "ownerPubkey": "BGYWnqfaauCeebFQXEfYuDCktiVG8pqpprrsD4qfqL53"
         },
         {
           "price": 20.95,
           "quantity": 1.3,
-          "owner_pubkey": "F1SZxEDxxCSLVjEBbMEjDYqajWRJQRCZBwPQnmcVvTLV"
+          "ownerPubkey": "F1SZxEDxxCSLVjEBbMEjDYqajWRJQRCZBwPQnmcVvTLV"
         },
         {
           "price": 21.31,
           "quantity": 30,
-          "owner_pubkey": "5gHsqmFsMaguM3HMyEmnME4NMQKj6NrJWUGv6VKnc2Hk"
+          "ownerPubkey": "5gHsqmFsMaguM3HMyEmnME4NMQKj6NrJWUGv6VKnc2Hk"
         }
     ],
     "slot": 190826373,
@@ -147,14 +147,14 @@ L3 Update - Sent per side
         {
           "price": 20.92,
           "quantity": 61.93,
-          "owner_pubkey": "BGYWnqfaauCeebFQXEfYuDCktiVG8pqpprrsD4qfqL53"
+          "ownerPubkey": "BGYWnqfaauCeebFQXEfYuDCktiVG8pqpprrsD4qfqL53"
         }
       ],
       "removals": [
         {
           "price": 20.92,
           "quantity": 61.910000000000004,
-          "owner_pubkey": "BGYWnqfaauCeebFQXEfYuDCktiVG8pqpprrsD4qfqL53"
+          "ownerPubkey": "BGYWnqfaauCeebFQXEfYuDCktiVG8pqpprrsD4qfqL53"
         }
       ],
       "slot": 197077534,

--- a/service-mango-orderbook/README.md
+++ b/service-mango-orderbook/README.md
@@ -76,6 +76,7 @@ L2 Update - Sent per side
 ### L3 Data 
 
 Subscribe to L3 updates
+:warning: If the subscribed market is a perp market, `owner_pubkey` corresponds to a `mangoAccount`, if the subscribed market is a spot market, `owner_pubkey` corresponds to an open orders account.
 
 ```
 {

--- a/service-mango-orderbook/src/lib.rs
+++ b/service-mango-orderbook/src/lib.rs
@@ -5,6 +5,7 @@ pub type OrderbookLevel = [f64; 2];
 pub type Orderbook = Vec<Order>;
 
 #[derive(Clone, Debug, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
 pub struct Order {
     pub price: f64,
     pub quantity: f64,

--- a/service-mango-orderbook/src/lib.rs
+++ b/service-mango-orderbook/src/lib.rs
@@ -2,9 +2,17 @@ use mango_feeds_lib::OrderbookSide;
 use serde::{ser::SerializeStruct, Serialize, Serializer};
 
 pub type OrderbookLevel = [f64; 2];
+pub type Orderbook = Vec<Order>;
+
+#[derive(Clone, Debug, Serialize, PartialEq)]
+pub struct Order {
+    pub price: f64,
+    pub quantity: f64,
+    pub owner_pubkey: String,
+}
 
 #[derive(Clone, Debug)]
-pub struct OrderbookUpdate {
+pub struct LevelUpdate {
     pub market: String,
     pub side: OrderbookSide,
     pub update: Vec<OrderbookLevel>,
@@ -12,12 +20,12 @@ pub struct OrderbookUpdate {
     pub write_version: u64,
 }
 
-impl Serialize for OrderbookUpdate {
+impl Serialize for LevelUpdate {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("OrderbookUpdate", 5)?;
+        let mut state = serializer.serialize_struct("LevelUpdate", 5)?;
         state.serialize_field("market", &self.market)?;
         state.serialize_field("side", &self.side)?;
         state.serialize_field("update", &self.update)?;
@@ -29,7 +37,7 @@ impl Serialize for OrderbookUpdate {
 }
 
 #[derive(Clone, Debug)]
-pub struct OrderbookCheckpoint {
+pub struct LevelCheckpoint {
     pub market: String,
     pub bids: Vec<OrderbookLevel>,
     pub asks: Vec<OrderbookLevel>,
@@ -37,12 +45,64 @@ pub struct OrderbookCheckpoint {
     pub write_version: u64,
 }
 
-impl Serialize for OrderbookCheckpoint {
+impl Serialize for LevelCheckpoint {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        let mut state = serializer.serialize_struct("OrderbookCheckpoint", 3)?;
+        let mut state = serializer.serialize_struct("LevelCheckpoint", 3)?;
+        state.serialize_field("market", &self.market)?;
+        state.serialize_field("bids", &self.bids)?;
+        state.serialize_field("asks", &self.asks)?;
+        state.serialize_field("slot", &self.slot)?;
+        state.serialize_field("write_version", &self.write_version)?;
+
+        state.end()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BookUpdate {
+    pub market: String,
+    pub side: OrderbookSide,
+    pub additions: Vec<Order>,
+    pub removals: Vec<Order>,
+    pub slot: u64,
+    pub write_version: u64,
+}
+
+impl Serialize for BookUpdate {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("BookUpdate", 6)?;
+        state.serialize_field("market", &self.market)?;
+        state.serialize_field("side", &self.side)?;
+        state.serialize_field("additions", &self.additions)?;
+        state.serialize_field("removals", &self.removals)?;
+        state.serialize_field("slot", &self.slot)?;
+        state.serialize_field("write_version", &self.write_version)?;
+
+        state.end()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct BookCheckpoint {
+    pub market: String,
+    pub bids: Vec<Order>,
+    pub asks: Vec<Order>,
+    pub slot: u64,
+    pub write_version: u64,
+}
+
+impl Serialize for BookCheckpoint {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut state = serializer.serialize_struct("LevelCheckpoint", 5)?;
         state.serialize_field("market", &self.market)?;
         state.serialize_field("bids", &self.bids)?;
         state.serialize_field("asks", &self.asks)?;
@@ -54,6 +114,8 @@ impl Serialize for OrderbookCheckpoint {
 }
 
 pub enum OrderbookFilterMessage {
-    Update(OrderbookUpdate),
-    Checkpoint(OrderbookCheckpoint),
+    LevelUpdate(LevelUpdate),
+    LevelCheckpoint(LevelCheckpoint),
+    BookUpdate(BookUpdate),
+    BookCheckpoint(BookCheckpoint),
 }

--- a/service-mango-orderbook/src/orderbook_filter.rs
+++ b/service-mango-orderbook/src/orderbook_filter.rs
@@ -187,7 +187,7 @@ fn publish_changes(
                 .map(|(price, group)| [price, group.map(|o| o.quantity).sum()])
                 .collect();
 
-            let ask_levels = bids
+            let ask_levels = asks
                 .iter()
                 .group_by(|order| order.price)
                 .into_iter()


### PR DESCRIPTION
Adds an L3 option to the mango-orderbook feed. Similarly to the L2 data, the feed sends a checkpoint upon subscription and updates. 

Notably, updates consist of additions and removals only, I wasn't sure if we'd want to support changes to orders as well.