### PR TITLE
Add metdata feed

### DIFF
--- a/connector/examples/combined_example_consumer.rs
+++ b/connector/examples/combined_example_consumer.rs
@@ -98,6 +98,7 @@ async fn main() -> anyhow::Result<()> {
         &config,
         &filter_config,
         account_write_queue_sender,
+        None,
         slot_queue_sender,
         metrics_tx.clone(),
         exit.clone(),

--- a/connector/examples/geyser_example_consumer.rs
+++ b/connector/examples/geyser_example_consumer.rs
@@ -98,6 +98,7 @@ async fn main() -> anyhow::Result<()> {
         &config,
         &filter_config,
         account_write_queue_sender,
+        None,
         slot_queue_sender,
         metrics_tx.clone(),
         exit.clone(),

--- a/connector/examples/websocket_example_consumer.rs
+++ b/connector/examples/websocket_example_consumer.rs
@@ -80,6 +80,7 @@ async fn main() -> anyhow::Result<()> {
         &config,
         &filter_config,
         account_write_queue_sender,
+        None,
         slot_queue_sender,
     )
     .await;

--- a/connector/src/lib.rs
+++ b/connector/src/lib.rs
@@ -28,6 +28,12 @@ impl<T, E: std::fmt::Debug> AnyhowWrap for Result<T, E> {
     }
 }
 
+pub enum FeedMetadata {
+    InvalidAccount(Pubkey),
+    SnapshotStart,
+    SnapshotEnd,
+}
+
 #[derive(Clone, PartialEq, Debug)]
 pub struct AccountWrite {
     pub pubkey: Pubkey,


### PR DESCRIPTION
Clients should be able to do some action on snapshot (freeze computation until receiving last update from a snapshot), and to have a list of empty account. 
Add an optional metadata message channel for this purpose.